### PR TITLE
New regalloc heuristic + some tests

### DIFF
--- a/compiler/src/compilerExamples/RegAllocTests.v
+++ b/compiler/src/compilerExamples/RegAllocTests.v
@@ -261,7 +261,7 @@ Defined.
 
 Module PrintSomeRegsAsm.
   Import riscv.Utility.InstructionNotations.
-  Goal True. let r := eval unfold some_regs_asm in some_regs_asm in idtac r. Abort.
+  Goal True. let r := eval unfold some_regs_asm in some_regs_asm in idtac (* r *). Abort.
 End PrintSomeRegsAsm.
 
 Definition long_some_regs := func! (reg_a0, b0) ~> (reg_a19, b19) {
@@ -374,7 +374,7 @@ Defined.
 
 Module PrintLongSomeRegsAsm.
   Import riscv.Utility.InstructionNotations.
-  Goal True. let r := eval unfold long_some_regs_asm in long_some_regs_asm in idtac r. Abort.
+  Goal True. let r := eval unfold long_some_regs_asm in long_some_regs_asm in idtac (* r *). Abort.
 End PrintLongSomeRegsAsm.
 
 
@@ -488,81 +488,8 @@ Defined.
 
 Module PrintLongNoRegsAsm.
   Import riscv.Utility.InstructionNotations.
-  Goal True. let r := eval unfold long_no_regs_asm in long_no_regs_asm in idtac r. Abort.
+  Goal True. let r := eval unfold long_no_regs_asm in long_no_regs_asm in idtac (* r *). Abort.
 End PrintLongNoRegsAsm.
-
-
-
-
-(* Definition long_lived_in_regs := *)
-(*   func! (reg_a0) ~> (reg_a0) { *)
-(*       reg_a1  = reg_a0 +  $1; *)
-(*       reg_a2  = reg_a0 +  $2; *)
-(*       reg_a3  = reg_a0 +  $3; *)
-(*       reg_a4  = reg_a0 +  $4; *)
-(*       reg_a5  = reg_a0 +  $5; *)
-(*       reg_a6  = reg_a0 +  $6; *)
-(*       reg_a7  = reg_a0 +  $7; *)
-(*       reg_a8  = reg_a0 +  $8; *)
-(*       reg_a9  = reg_a0 +  $9; *)
-(*       reg_a10 = reg_a0 + $10; *)
-(*       reg_a11 = reg_a0 + $11; *)
-(*       reg_a12 = reg_a0 + $12; *)
-(*       reg_a13 = reg_a0 + $13; *)
-(*       reg_a14 = reg_a0 + $14; *)
-(*       reg_a15 = reg_a0 + $15; *)
-(*       reg_a16 = reg_a0 + $16; *)
-
-(*       b1 = b1 + reg_a1; *)
-(*       reg_a1 = reg_a1 + b1; *)
-(*       b2 = b2 + reg_a2; *)
-(*       reg_a2 = reg_a2 + b2; *)
-(*       b3 = b3 + reg_a3; *)
-(*       reg_a3 = reg_a3 + b3; *)
-(*       b4 = b4 + reg_a4; *)
-(*       reg_a4 = reg_a4 + b4; *)
-(*       b5 = b5 + reg_a5; *)
-(*       reg_a5 = reg_a5 + b5; *)
-(*       b6 = b6 + reg_a6; *)
-(*       reg_a6 = reg_a6 + b6; *)
-(*       b7 = b7 + reg_a7; *)
-(*       reg_a7 = reg_a7 + b7; *)
-(*       b8 = b8 + reg_a8; *)
-(*       reg_a8 = reg_a8 + b8; *)
-(*       b9 = b9 + reg_a9; *)
-(*       reg_a9 = reg_a9 + b9; *)
-(*       b10 = b10 + reg_a10; *)
-(*       reg_a10 = reg_a10 + b10; *)
-(*       b11 = b11 + reg_a11; *)
-(*       reg_a11 = reg_a11 + b11; *)
-(*       b12 = b12 + reg_a12; *)
-(*       reg_a12 = reg_a12 + b12; *)
-(*       b13 = b13 + reg_a13; *)
-(*       reg_a13 = reg_a13 + b13; *)
-(*       b14 = b14 + reg_a14; *)
-(*       reg_a14 = reg_a14 + b14; *)
-(*       b15 = b15 + reg_a15; *)
-(*       reg_a15 = reg_a15 + b15; *)
-(*       b16 = b16 + reg_a16; *)
-(*       reg_a16 = reg_a16 + b16; *)
-
-(*       reg_a0 = reg_a16 *)
-(* }. *)
-
-(* Definition long_lived_in_regs_asm: list Instruction. *)
-(*   let r := eval cbv in (compile compile_ext_call &[,long_lived_in_regs]) in set (res := r). *)
-(*   match goal with *)
-(*   | res := Success (?x, _, _) |- _ => exact x *)
-(*   end. *)
-(* Defined. *)
-
-(* Module PrintLongLivedInRegsAsm. *)
-(*   Import riscv.Utility.InstructionNotations. *)
-(*   Goal True. let r := eval unfold long_lived_in_regs_asm in long_lived_in_regs_asm in idtac r. Abort. *)
-(* End PrintLongLivedInRegsAsm. *)
-
-
-
 
 
 

--- a/compiler/src/compilerExamples/RegAllocTests.v
+++ b/compiler/src/compilerExamples/RegAllocTests.v
@@ -34,13 +34,7 @@ Open Scope ilist_scope.
 (* Preliminaries *)
 (* ********************************************************* *)
 
-Definition var: Set := Z.
-Definition Reg: Set := Z.
-
-
 Local Existing Instance DefaultRiscvState.
-
-Axiom TODO: forall {T: Type}, T.
 
 Local Instance funpos_env: map.map string Z := SortedListString.map _.
 
@@ -54,31 +48,8 @@ Definition compile_ext_call(posenv: funpos_env)(mypos stackoffset: Z)(s: FlatImp
   | _ => []
   end.
 
-Notation RiscvMachine := MetricRiscvMachine.
-
 Local Existing Instance coqutil.Map.SortedListString.map.
 Local Existing Instance coqutil.Map.SortedListString.ok.
-
-Definition main_stackalloc := func! {
-  stackalloc 4 as x; stackalloc 4 as y; swap_swap(x, y) }.
-
-
-(* stack grows from high addreses to low addresses, first stack word will be written to
-   (stack_pastend-8), next stack word to (stack_pastend-16) etc *)
-Definition stack_pastend: Z := 2048.
-
-Lemma f_equal2: forall {A B: Type} {f1 f2: A -> B} {a1 a2: A},
-    f1 = f2 -> a1 = a2 -> f1 a1 = f2 a2.
-Proof. intros. congruence. Qed.
-
-Lemma f_equal3: forall {A B C: Type} {f1 f2: A -> B -> C} {a1 a2: A} {b1 b2: B},
-    f1 = f2 -> a1 = a2 -> b1 = b2 -> f1 a1 b1 = f2 a2 b2.
-Proof. intros. congruence. Qed.
-
-Lemma f_equal3_dep: forall {A B C: Type} {f1 f2: A -> B -> C} {a1 a2: A} {b1 b2: B},
-    f1 = f2 -> a1 = a2 -> b1 = b2 -> f1 a1 b1 = f2 a2 b2.
-Proof. intros. congruence. Qed.
-
 
 Local Instance RV32I_bitwidth: FlatToRiscvCommon.bitwidth_iset 32 RV32I.
 Proof. reflexivity. Qed.
@@ -490,6 +461,5 @@ Module PrintLongNoRegsAsm.
   Import riscv.Utility.InstructionNotations.
   Goal True. let r := eval unfold long_no_regs_asm in long_no_regs_asm in idtac (* r *). Abort.
 End PrintLongNoRegsAsm.
-
 
 


### PR DESCRIPTION
Unfortunately I accidentally pushed to the wrong branch and some of the commits are already in the git history of Andy's branch. Sorry about that! I reverted those, but let me know if there's a better way to fix this.

I added some tests for the better register allocator heuristic. Some of the tests fail to compile without the heuristic, because the compiler doesn't know to prioritize `reg_` variables for putting in registers; however, the ones that are expected to compile do indeed compile with the new heuristic.